### PR TITLE
Allow for defining arbitrary project version and name in configuratio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ apidocs/
 .tox/
 .coverage.*
 .vscode
+.idea
 .python-version

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,8 @@ Towncrier has the following global options, which can be specified in the toml f
     single_file = true  # if false, filename is formatted like `title_format`.
     filename = "NEWS.rst"
     directory = "directory/of/news/fragments"
+    project_version = "project version if maintained separately"
+    project_name = "arbitrary project name"
     template = "path/to/template.rst"
     start_line = "start of generated content"
     title_format = "{name} {version} ({project_date})"  # or false if template includes title

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -144,6 +144,8 @@ def parse_toml(base_path, config):
         "single_file": single_file,
         "filename": config.get("filename", "NEWS.rst"),
         "directory": config.get("directory"),
+        "project_version": config.get("project_version"),
+        "project_name": config.get("project_name"),
         "sections": sections,
         "types": types,
         "template": template,

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -119,20 +119,24 @@ def __main(
     )
 
     if project_version is None:
-        project_version = get_version(
-            os.path.join(base_directory, config["package_dir"]), config["package"]
-        ).strip()
+        project_version = config.get('project_version')
+        if project_version is None:
+            project_version = get_version(
+                os.path.join(base_directory, config["package_dir"]), config["package"]
+            ).strip()
 
     if project_name is None:
-        package = config.get("package")
-        if package:
-            project_name = get_project_name(
-                os.path.abspath(os.path.join(base_directory, config["package_dir"])),
-                package,
-            )
-        else:
-            # Can't determine a project_name, but maybe it is not needed.
-            project_name = ""
+        project_name = config.get('project_name')
+        if not project_name:
+            package = config.get("package")
+            if package:
+                project_name = get_project_name(
+                    os.path.abspath(os.path.join(base_directory, config["package_dir"])),
+                    package,
+                )
+            else:
+                # Can't determine a project_name, but maybe it is not needed.
+                project_name = ""
 
     if project_date is None:
         project_date = _get_date().strip()

--- a/src/towncrier/newsfragments/165.feature.rst
+++ b/src/towncrier/newsfragments/165.feature.rst
@@ -1,0 +1,2 @@
+Allow to define ``project_version`` and ``project_name`` in configuration.
+This allows to use towncrier seamlessly in the non-pythyon projects.


### PR DESCRIPTION
…n - close #165

    This allows for the towncrier to be seamlessly used in non-python projects